### PR TITLE
Add ability to specify a list of Cassandra instances manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ autoscale_group: this is the long name of your autoscale group as per the EC2 co
                 s3_base_path: "mybackup"
                 autoscale_group: "myautoscalegroup"
 
+If your cluster is not running in AWS (or is not wrapped into ASG) you can also specify a list of instances manually; in order to do so first set autoscale_group to 'None' and then specify a string of hosts that form the cluster
+
+        snapshot:
+            myproduct:
+                aws_access_key_id: "XXXXXXXXXXXXXXXXXXXX"
+                aws_secret_access_key: "XXXXXXXXXXXXXXXXXXX"
+                s3_bucket_name: "mybucket"
+                s3_bucket_region: "eu-west-1"
+                s3_base_path: "mybackup"
+                autoscale_group: "None"
+                instances: "fqdn-1,fqdn-2"
+
 You will now need to create /var/log/snapshotter and ensure that the user you intend to use has write access to it. Logs will appear here in the format myproduct_snapshotter.log
 
 

--- a/run_snapshotter.py
+++ b/run_snapshotter.py
@@ -88,7 +88,12 @@ def main():
     except:
         logger.error('Product %s not found in config.yaml' % args.p)
         sys.exit(2)
-    instances = get_hosts_from_asg(config['snapshot'][args.p])
+
+    if config['snapshot'][args.p]['autoscale_group'] == 'None':
+        instances = config['snapshot'][args.p]['instances']
+    else:
+        instances = get_hosts_from_asg(config['snapshot'][args.p])
+
     command = get_command(config['snapshot'][args.p], instances)
     if DEBUG:
         logger.debug('Executing command in subprocess: %s' % command)

--- a/snapshotter_config.yaml.sample
+++ b/snapshotter_config.yaml.sample
@@ -6,4 +6,12 @@ snapshot:
         s3_bucket_region: "eu-west-1"
         s3_base_path: "mybackup"
         autoscale_group: "myautoscalegroup"
+    myproduct-not-in-aws:
+        aws_access_key_id: "XXXXXXXXXXXXXXXXXXXX"
+        aws_secret_access_key: "XXXXXXXXXXXXXXXXXXX"
+        s3_bucket_name: "mybucket"
+        s3_bucket_region: "eu-west-1"
+        s3_base_path: "mybackup"
+        autoscale_group: "None"
+        instances: "fqdn-1,fqdn-2"
 


### PR DESCRIPTION
If Cassandra cluster is not running in AWS (or is running in AWS but is not wrapped into ASG) it's desired to specify the lists of instances manually; this PR implements this functionality
